### PR TITLE
Fix demo startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,4 @@ install the dependencies:
 `npm install`  # Or use `yarn install` if you prefer yarn over npm
 
 run the application:
-
-`npm serve`  # Or use `yarn serve`
+`npm run serve`  # Or use `yarn serve`


### PR DESCRIPTION
## Summary
- correct example's startup command in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e363784c083329b8c4ae3c3f9f0f9